### PR TITLE
perform strikethrough to the checked task

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -98,6 +98,7 @@ function submitHandler(event) {
     category: categoryEl.value,
     activity: activityEl.value,
     priority: priorityEl.checked,
+    isChecked: false,
   }
 
   const existingTasks = getTasksFromLocalStorage()
@@ -321,8 +322,12 @@ function createTaskElement(task) {
   <div class="task__container">
     <div class="task__container-top">
       <div class="task__name">
-        <input type="checkbox" name="" id="mockID" />
-        <label for="mockID">${task.taskName}</label>
+        <button class="task-checkbox ${
+          task.isChecked ? 'checked' : ''
+        }" onclick="toggleCheckbox(${task.id})"></button>
+        <label class="task-name ${
+          task.isChecked ? 'checked' : ''
+        }" for="mockID">${task.taskName}</label>
       </div>
       <div>
         <i class="fa-solid fa-angle-down" id="show-btn" onclick="showButton(event)"></i>
@@ -442,6 +447,17 @@ function showError(element, message) {
   element.textContent = message
   element.classList.remove('hidden')
   return true // Return true to indicate that an error occurred
+}
+
+// function to toggle the task checkbox
+function toggleCheckbox(taskId) {
+  const tasks = getTasksFromLocalStorage()
+  const taskIndex = tasks.findIndex((task) => task.id === String(taskId))
+  if (taskIndex !== -1) {
+    tasks[taskIndex].isChecked = !tasks[taskIndex].isChecked
+    localStorage.setItem('tasks', JSON.stringify(tasks))
+    populateTasks(selectedDay)
+  }
 }
 
 // function for show button on task-card

--- a/public/styles.css
+++ b/public/styles.css
@@ -160,22 +160,28 @@ input {
   display: none;
 }
 
-.hidden__custom-checkbox {
+.hidden__custom-checkbox,
+.task-checkbox {
   height: 16px;
   width: 16px;
   border: solid 1px #6d6d6d;
+  background-color: inherit;
   border-radius: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: pointer;
 }
 
-.hidden__main-checkbox:checked + .hidden__custom-checkbox {
+.hidden__main-checkbox:checked + .hidden__custom-checkbox,
+.task-checkbox.checked {
   border: none;
   background-color: #34d3a2;
+  cursor: pointer;
 }
 
-.hidden__main-checkbox:checked + .hidden__custom-checkbox::after {
+.hidden__main-checkbox:checked + .hidden__custom-checkbox::after,
+.task-checkbox.checked::after {
   content: '\2713';
   font-size: 8px;
   font-weight: 1000;
@@ -398,7 +404,6 @@ span#closeBtn:hover {
 }
 
 /* task section styles */
-
 .task__section {
   display: flex;
   flex-direction: column;
@@ -555,6 +560,12 @@ span#closeBtn:hover {
   font-size: 1.5rem;
 
   transform: rotate(110deg);
+}
+
+/* task name */
+.task-name.checked {
+  text-decoration: line-through;
+  color: #888888;
 }
 
 /* buttons inside modals styles */


### PR DESCRIPTION
Hi guys, I now finished the function where the task's name will get a line-through when the task is checked. 

- I modified our task object (I added the "isChecked" property), we can use this property later in our project when we implement the remaining tasks and done tasks indicator.
- I added a function toggleCheckbox() that accepts the current task id and toggle the task's isChecked property. (This took me a while to finish cause the task.id is on string and the other id I'm comparing it with is a number)
- modified the createTaskElement(): 
```
<div class="task__name">
        <button class="task-checkbox ${
          task.isChecked ? 'checked' : ''
        }" onclick="toggleCheckbox(${task.id})"></button>
        <label class="task-name ${
          task.isChecked ? 'checked' : ''
        }" for="mockID">${task.taskName}</label>
      </div>
```
- lastly, I also modified the css file where I added the new class names and stylings.

NOTE: The functionality only works on the newly created task since the isChecked property will not exist on the already created task. Please clear your localStorage first to avoid some issues. 