### PR TITLE
Weekly options task jimmy

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -635,13 +635,13 @@ function renderDesktopCalendar() {
     )
 
     const prevMonthDayString = prevMonthDay.toLocaleString().split(',')[0]
-    const isDue = checkDateTask(getSimpleDate(prevMonthDay))
+    const hasTasks = checkDateTask(getSimpleDate(prevMonthDay))
 
     gridDates += `<div class="grid-date prevMonthDate ${
-      isDue ? 'due-task' : ''
+      hasTasks ? 'due-task' : ''
     }" data-date='${prevMonthDayString}' onclick="
       setSelectedDay('${prevMonthDayString}')">
-      ${isDue ? "<i class='fa-solid fa-file'></i>" : ''}
+      ${hasTasks ? "<i class='fa-solid fa-file'></i>" : ''}
       ${prevMonthLastDay.getDate() - i + 1}
       </div>`
   }
@@ -655,15 +655,17 @@ function renderDesktopCalendar() {
     )
 
     const currentMonthDayString = currentMonthDay.toLocaleString().split(',')[0]
-    const isDue = checkDateTask(getSimpleDate(currentMonthDay))
+    const hasTasks = checkDateTask(getSimpleDate(currentMonthDay))
 
     gridDates += `<div class="grid-date ${
       getSimpleDate(currentMonthDay) === getSimpleDate(selectedDay)
         ? 'selected'
         : ''
-    } ${isDue ? 'due-task' : ''}" data-date='${currentMonthDayString}' onclick="
+    } ${
+      hasTasks ? 'due-task' : ''
+    }" data-date='${currentMonthDayString}' onclick="
     setSelectedDay('${currentMonthDayString}')">
-    ${isDue ? "<i class='fa-solid fa-file'></i>" : ''}
+    ${hasTasks ? "<i class='fa-solid fa-file'></i>" : ''}
     ${currentMonthDay.getDate()}
     </div>`
   }
@@ -676,13 +678,13 @@ function renderDesktopCalendar() {
       nextMonthFirstDay.getDate() + k
     )
     const nextMonthDayString = nextMonthDay.toLocaleString().split(',')[0]
-    const isDue = checkDateTask(getSimpleDate(nextMonthDay))
+    const hasTasks = checkDateTask(getSimpleDate(nextMonthDay))
 
     gridDates += `<div class="grid-date nextMonthDate ${
-      isDue ? 'due-task' : ''
+      hasTasks ? 'due-task' : ''
     }" data-date='${nextMonthDayString}' onclick="
     setSelectedDay('${nextMonthDayString}')">
-    ${isDue ? "<i class='fa-solid fa-file'></i>" : ''}
+    ${hasTasks ? "<i class='fa-solid fa-file'></i>" : ''}
     ${nextMonthDay.getDate()}
     </div>`
   }


### PR DESCRIPTION
Changes I made in this pull request:
 -  Remove the 'deadline' key from the task object, instead I used the key 'dueDates' (array) for both task with a single due date and task with repeated days
 - For task with a single due date, add the key 'isCompleted' which can be true or false.
 - For task with repeated days, add the key 'selectedDaysIndex', and  add the key 'completedDates' (array). When the user mark a task as completed on a certain day, the date will be add to this array.
 - Modify the _getRepeatDays_ so it returns array of indexes instead of selected days, so [1, 2] instead of [Monday, Tuesday]
 - Modify the createTaskElement so that it receives a second argument createTaskElement(task, **date**)
 - Create the _generateActualDates()_ function to create an array of due dates, starting from next week.
 - Some variable name changes.
 - Temporary disable the renderSummary() function - TO DO: display the to do and done tasks for each selected day instead of looping over the whole tasks array.